### PR TITLE
Fixed warning generated by isSet()

### DIFF
--- a/20-20-20-Eyesafe-project.py
+++ b/20-20-20-Eyesafe-project.py
@@ -16,7 +16,7 @@ def setInterval(interval, times = -1):
             # in a different thread to simulate setInterval
             def inner_wrap():
                 i = 0
-                while i != times and not stop.isSet():
+                while i != times and not stop.is_set():
                     stop.wait(interval)
                     function(*args, **kwargs)
                     i += 1


### PR DESCRIPTION
Changed isSet() to is_set().

## Description

Since isSet() was deprecated, I have changed it with the is_set() method.

Fixes #5 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have registered myself at [Contrihub website](https://sac.mnnit.ac.in/contrihub).
- [x] My code follows the code style of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
